### PR TITLE
[codex] Fix PR feedback issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
@@ -23,4 +23,4 @@ jobs:
         options: "--check --verbose"
     - run: uv run pytest --cov=podcast_transcript_convert --cov-report=term-missing
     - run: uv run pyroma . --min=10
-    - run: uv run python -m podcast_transcript_convert --help | grep -q 'usage: transcript2json'
+    - run: "uv run python -m podcast_transcript_convert --help | grep -q 'usage: transcript2json'"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: "3.13"
+        enable-cache: false
     - name: Build distributions
       run: uv build
     - name: Publish package distributions to PyPI

--- a/podcast_transcript_convert/__main__.py
+++ b/podcast_transcript_convert/__main__.py
@@ -82,12 +82,25 @@ def _read_ignore_list(ignore_file: Path | None) -> list[str]:
     ]
 
 
-def _convert_single_file(source: Path, destination: Path) -> int:
+def _convert_single_file(
+    source: Path,
+    destination: Path,
+    *,
+    overwrite: bool = False,
+    dry_run: bool = False,
+) -> int:
     if destination.is_dir() or destination.suffix == "":
-        destination.mkdir(parents=True, exist_ok=True)
         destination = destination / (source.stem + ".json")
-    else:
-        destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.exists() and not overwrite:
+        logger.info(f"Skipping existing {destination}")
+        return 1
+
+    if dry_run:
+        logger.info(f"Dry run: would convert {source} -> {destination}")
+        return 0
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
     try:
         convert_file(source, destination)
     except (TranscriptConversionError, OSError) as e:
@@ -106,10 +119,16 @@ def main(argv: list[str] | None = None) -> int:
 
     source = Path(args.source)
     if source.is_file() and source.suffix != ".db":
-        return _convert_single_file(source, Path(args.destination))
+        return _convert_single_file(
+            source,
+            Path(args.destination),
+            overwrite=args.overwrite,
+            dry_run=args.dry_run,
+        )
 
     ignore_list = _read_ignore_list(args.ignore_file)
-    Path(args.destination).mkdir(parents=True, exist_ok=True)
+    if not args.dry_run:
+        Path(args.destination).mkdir(parents=True, exist_ok=True)
 
     summary = bulk_convert(
         transcript_path=args.source,
@@ -118,7 +137,7 @@ def main(argv: list[str] | None = None) -> int:
         overwrite=args.overwrite,
         dry_run=args.dry_run,
     )
-    if summary.failed and not summary.converted:
+    if summary.failed or not summary.converted:
         return 1
     return 0
 

--- a/podcast_transcript_convert/convert.py
+++ b/podcast_transcript_convert/convert.py
@@ -137,9 +137,12 @@ def bulk_convert(
         logger.warning(f"Unknown: {summary.unknown}")
 
     jobs: list[tuple[str, Converter]] = sorted(
-        (file_path, converter)
-        for file_type, converter in FILE_CONVERTERS.items()
-        for file_path in grouped[file_type]
+        (
+            (file_path, converter)
+            for file_type, converter in FILE_CONVERTERS.items()
+            for file_path in grouped[file_type]
+        ),
+        key=lambda job: job[0],
     )
     destinations = _assign_destinations(
         [file_path for file_path, _ in jobs],

--- a/podcast_transcript_convert/converters/vtt_to_json.py
+++ b/podcast_transcript_convert/converters/vtt_to_json.py
@@ -2,6 +2,7 @@ from json import dumps
 from pathlib import Path
 
 import webvtt  # type: ignore[import-not-found]
+from loguru import logger
 from webvtt.errors import MalformedFileError
 
 from podcast_transcript_convert.errors import InvalidVttError
@@ -41,12 +42,15 @@ def vtt_file_to_json_file(
     json_file: str | Path,
     metadata: dict | None,
 ) -> None:
-    vtt_string = read_text_robust(vtt_file)
     try:
+        vtt_string = read_text_robust(vtt_file)
         transcript_dict = vtt_to_podcast_dict(vtt_string)
         if metadata:
             transcript_dict["metadata"] = metadata
     except InvalidVttError as e:
         e.add_note(str(vtt_file))
         raise
+    except FileNotFoundError:
+        logger.error(f"File not found: {vtt_file}")
+        return
     write_text_utf8(json_file, dumps(transcript_dict, indent=4))

--- a/podcast_transcript_convert/converters/xml_to_json.py
+++ b/podcast_transcript_convert/converters/xml_to_json.py
@@ -30,9 +30,10 @@ def _xml_to_segments(soup: BeautifulSoup) -> list[Segment]:
                         segments[-1].start_time = _mts_to_secs_float(str(item["start"]))
 
                     segments[-1].end_time = _mts_to_secs_float(str(item["end"]))
-    if not segments[0].to_dict():
+    populated_segments = [segment for segment in segments if segment.to_dict()]
+    if not populated_segments:
         raise NoTranscriptFoundError
-    return segments
+    return populated_segments
 
 
 def xml_to_podcast_dict(xml_string: str) -> dict:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+import podcast_transcript_convert.convert as convert_module
 from podcast_transcript_convert.convert import (
     _assign_destinations,
     _destination_path,
@@ -127,6 +128,35 @@ def test_bulk_convert_dry_run_writes_nothing(tmp_path: Path):
     assert summary.dry_run
     assert len(summary.converted) == 1
     assert not destination.exists()
+
+
+def test_bulk_convert_duplicate_sources_do_not_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = tmp_path / "in"
+    source.mkdir()
+    transcript = source / "ep.srt"
+    transcript.write_text(VALID_SRT)
+    destination = tmp_path / "out"
+
+    def duplicate_list_files(directory: str, ignore: list[str]) -> list[str]:
+        assert directory == str(source)
+        assert ignore == []
+        return [str(transcript), str(transcript)]
+
+    monkeypatch.setattr(
+        convert_module,
+        "list_files",
+        duplicate_list_files,
+    )
+
+    summary = convert_module.bulk_convert(str(source), str(destination), dry_run=True)
+
+    assert [src for src, _ in summary.converted] == [
+        str(transcript),
+        str(transcript),
+    ]
 
 
 def test_bulk_convert_ignore_list(tmp_path: Path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,6 +59,29 @@ def test_main_single_file_to_file(tmp_path: Path):
     assert destination.exists()
 
 
+def test_main_single_file_dry_run_writes_nothing(tmp_path: Path):
+    source = tmp_path / "ep.srt"
+    source.write_text(VALID_SRT)
+    destination = tmp_path / "out"
+
+    assert main(["--dry-run", str(source), str(destination)]) == 0
+    assert not destination.exists()
+
+
+def test_main_single_file_skips_existing_unless_overwrite(tmp_path: Path):
+    source = tmp_path / "ep.srt"
+    source.write_text(VALID_SRT)
+    destination = tmp_path / "converted.json"
+    destination.write_text("original")
+
+    assert main([str(source), str(destination)]) == 1
+    assert destination.read_text() == "original"
+
+    assert main(["--overwrite", str(source), str(destination)]) == 0
+    data = json.loads(destination.read_text())
+    assert data["segments"][0]["body"] == "Hello world."
+
+
 def test_main_single_file_failure_exits_nonzero(tmp_path: Path):
     source = tmp_path / "bad.srt"
     source.write_text("this is not valid srt")
@@ -74,7 +97,35 @@ def test_main_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     destination = tmp_path / "out"
 
     assert main(["--dry-run", str(source), str(destination)]) == 0
-    assert not (destination / "ep.json").exists()
+    assert not destination.exists()
+
+
+def test_main_bulk_partial_failure_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "in"
+    source.mkdir()
+    (source / "good.srt").write_text(VALID_SRT)
+    (source / "bad.srt").write_text("this is not valid srt")
+    destination = tmp_path / "out"
+
+    assert main([str(source), str(destination)]) == 1
+    assert (destination / "good.json").exists()
+
+
+def test_main_bulk_unknown_only_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "in"
+    source.mkdir()
+    (source / "mystery.bin").write_text("not a transcript")
+    destination = tmp_path / "out"
+
+    assert main([str(source), str(destination)]) == 1
 
 
 def test_main_ignore_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_vtt.py
+++ b/tests/test_vtt.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from podcast_transcript_convert.converters.vtt_to_json import vtt_to_podcast_dict
+from podcast_transcript_convert.converters.vtt_to_json import (
+    vtt_file_to_json_file,
+    vtt_to_podcast_dict,
+)
 from podcast_transcript_convert.errors import InvalidVttError
 
 
@@ -69,3 +72,11 @@ def test_vtt_to_podcast_dict_with_numbered_blocks():
 def test_vtt_to_podcast_dict_with_invalid():
     with pytest.raises(InvalidVttError):
         vtt_to_podcast_dict("")
+
+
+def test_vtt_file_to_json_file_missing_file_returns(tmp_path: Path):
+    destination = tmp_path / "out.json"
+
+    vtt_file_to_json_file(tmp_path / "missing.vtt", destination, None)
+
+    assert not destination.exists()

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -11,8 +11,28 @@ def test_xml_to_podcast_dict():
     assert transcript_dict["segments"][0]["body"] == "Welcome to"
     assert transcript_dict["segments"][0]["startTime"] == 0.82
     assert transcript_dict["segments"][0]["endTime"] == 1.66
-    assert transcript_dict["segments"][-1]["body"] == """
+    assert (
+        transcript_dict["segments"][-1]["body"]
+        == """
 thanks everyone out there who listened to "The Open Source Way". If you enjoyed this episode, please share it and don't miss the next one. We usually publish every last Wednesday of the month, and you'll find us on openSAP and in all those places where you find your other podcasts . Either the mainstream apps that you know, or some of the, themselves, open-source podcast apps. Thanks again and bye bye.
     """.strip()
+    )
     assert transcript_dict["segments"][-1]["startTime"] == 1739.4
     assert transcript_dict["segments"][-1]["endTime"] == 1766.55
+
+
+def test_xml_to_podcast_dict_drops_empty_speech_segments():
+    xml_string = """<?xml version="1.0"?>
+    <podcast:transcripts xmlns:podcast="http://podlove.org/simple-transcripts">
+        <speech>
+            <item start="00:00:00.000" end="00:00:01.000">Hello</item>
+        </speech>
+        <speech></speech>
+    </podcast:transcripts>
+    """
+
+    transcript_dict = xml_to_podcast_dict(xml_string)
+
+    assert transcript_dict["segments"] == [
+        {"startTime": 0.0, "endTime": 1.0, "body": "Hello"},
+    ]


### PR DESCRIPTION
## Summary

This PR addresses the actionable feedback from PR #2 review triage.

- Pins `astral-sh/setup-uv` to a full commit SHA in CI workflows, quotes the lint workflow help-command check, and disables setup cache in the trusted publish job.
- Fixes CLI behavior so single-file conversion honors `--dry-run` and `--overwrite`, bulk dry-run avoids creating output directories, and bulk runs return nonzero for failures or zero converted files.
- Fixes conversion edge cases for duplicate source sorting, missing VTT inputs, and empty XML speech segments.
- Adds focused regression tests for the reviewed CLI and converter behaviors.

## Root Cause

The refactor added new CLI flags and concurrent bulk conversion behavior, but several edge paths were not wired through or covered: single-file conversion bypassed the new flags, bulk dry-run had a filesystem side effect, and exit-code semantics did not match the documented contract. The workflow comments were caused by a mutable third-party action pin and an unquoted YAML scalar containing `: `.

## Validation

- `uv run ruff check .`
- `uv run pytest` (74 passed)
- `uv run ty check podcast_transcript_convert`
- `uv run pyrefly check`
- `uv run pyroma . --min=10`
- `actionlint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/podcast-transcript-convert/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

