### PR TITLE
[codex] Propagate missing file errors from converters

### DIFF
--- a/podcast_transcript_convert/converters/html_to_json.py
+++ b/podcast_transcript_convert/converters/html_to_json.py
@@ -80,6 +80,6 @@ def html_file_to_json_file(
         raise
     except FileNotFoundError:
         logger.error(f"File not found: {html_file}")
-        return
+        raise
 
     write_text_utf8(json_file, dumps(transcript_dict, indent=4))

--- a/podcast_transcript_convert/converters/vtt_to_json.py
+++ b/podcast_transcript_convert/converters/vtt_to_json.py
@@ -52,5 +52,5 @@ def vtt_file_to_json_file(
         raise
     except FileNotFoundError:
         logger.error(f"File not found: {vtt_file}")
-        return
+        raise
     write_text_utf8(json_file, dumps(transcript_dict, indent=4))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -99,6 +99,34 @@ def test_bulk_convert_continues_after_failure(tmp_path: Path):
     assert (destination / "good.json").exists()
 
 
+def test_bulk_convert_records_missing_vtt_as_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    missing = tmp_path / "missing.vtt"
+    destination = tmp_path / "out"
+
+    def missing_vtt_from_db(
+        db_path: str,
+        ignore: list[str],
+    ) -> tuple[list[str], dict[str, dict[str, str]]]:
+        assert db_path == str(tmp_path / "overcast.db")
+        assert ignore == []
+        return [str(missing)], {}
+
+    monkeypatch.setattr(
+        convert_module,
+        "list_files_from_db",
+        missing_vtt_from_db,
+    )
+
+    summary = convert_module.bulk_convert(str(tmp_path / "overcast.db"), str(destination))
+
+    assert summary.converted == []
+    assert [src for src, _ in summary.failed] == [str(missing)]
+    assert list(destination.rglob("*.json")) == []
+
+
 def test_bulk_convert_skips_existing_unless_overwrite(tmp_path: Path):
     source = tmp_path / "in"
     source.mkdir()

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -4,6 +4,7 @@ import pytest
 
 from podcast_transcript_convert.converters.html_to_json import (
     _ts_to_secs,
+    html_file_to_json_file,
     html_to_podcast_dict,
 )
 from podcast_transcript_convert.errors import InvalidHtmlError
@@ -85,3 +86,12 @@ def test_html_to_podcast_dict_with_ts_looking_in_body():
 def test_html_to_podcast_dict_empty():
     with pytest.raises(InvalidHtmlError):
         html_to_podcast_dict("")
+
+
+def test_html_file_to_json_file_missing_file_raises(tmp_path: Path):
+    destination = tmp_path / "out.json"
+
+    with pytest.raises(FileNotFoundError):
+        html_file_to_json_file(tmp_path / "missing.html", destination, None)
+
+    assert not destination.exists()

--- a/tests/test_vtt.py
+++ b/tests/test_vtt.py
@@ -74,9 +74,10 @@ def test_vtt_to_podcast_dict_with_invalid():
         vtt_to_podcast_dict("")
 
 
-def test_vtt_file_to_json_file_missing_file_returns(tmp_path: Path):
+def test_vtt_file_to_json_file_missing_file_raises(tmp_path: Path):
     destination = tmp_path / "out.json"
 
-    vtt_file_to_json_file(tmp_path / "missing.vtt", destination, None)
+    with pytest.raises(FileNotFoundError):
+        vtt_file_to_json_file(tmp_path / "missing.vtt", destination, None)
 
     assert not destination.exists()


### PR DESCRIPTION
## Summary

- Re-raise `FileNotFoundError` from VTT and HTML converters after logging missing input files.
- Add regression coverage showing database-driven bulk conversion records a missing VTT source in `summary.failed` instead of `summary.converted`.
- Update converter-level missing-file tests to assert propagation and no output file.

## Root Cause

`bulk_convert` uses exceptions from converter calls to decide whether a file failed. The VTT converter was catching `FileNotFoundError`, logging it, and returning normally, so the bulk caller treated the missing input as a successful conversion. The HTML converter had the same pre-existing pattern.

## Validation

- `uv run --locked pytest`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/podcast-transcript-convert/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

