### PR TITLE
Standardize JSON converter failures

### DIFF
--- a/podcast_transcript_convert/converters/json_to_json.py
+++ b/podcast_transcript_convert/converters/json_to_json.py
@@ -1,8 +1,7 @@
 import json
 from pathlib import Path
 
-from loguru import logger  # type: ignore[import-not-found]
-
+from podcast_transcript_convert.errors import InvalidJsonError
 from podcast_transcript_convert.file_utils import read_text_robust, write_text_utf8
 
 
@@ -14,12 +13,18 @@ def json_file_to_json_file(
     try:
         data = json.loads(read_text_robust(origin_file))
     except json.JSONDecodeError as e:
-        e.add_note(str(origin_file))
-        raise
+        error = InvalidJsonError()
+        error.add_note(str(origin_file))
+        raise error from e
 
-    if "version" not in data or "segments" not in data:
-        logger.error(f"Non-spec JSON file: {origin_file}")
-        return
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("version"), str)
+        or not isinstance(data.get("segments"), list)
+    ):
+        error = InvalidJsonError()
+        error.add_note(str(origin_file))
+        raise error
 
     if metadata:
         data["metadata"] = metadata

--- a/podcast_transcript_convert/errors.py
+++ b/podcast_transcript_convert/errors.py
@@ -16,6 +16,13 @@ class InvalidHtmlError(TranscriptConversionError):
         super().__init__("The provided HTML file is not a valid transcript.")
 
 
+class InvalidJsonError(TranscriptConversionError):
+    """The JSON cannot be parsed as a PodcastIndex transcript."""
+
+    def __init__(self) -> None:
+        super().__init__("The provided JSON file is not a valid transcript.")
+
+
 class InvalidXmlError(TranscriptConversionError):
     """The XML does not conform to http://podlove.org/simple-transcripts ."""
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -106,6 +106,20 @@ def test_bulk_convert_continues_after_failure(tmp_path: Path):
     assert (destination / "good.json").exists()
 
 
+def test_bulk_convert_records_invalid_json_as_failure(tmp_path: Path):
+    source = tmp_path / "in"
+    source.mkdir()
+    invalid_json = source / "bad.json"
+    invalid_json.write_text(json.dumps({"version": "1.0.0"}))
+    destination = tmp_path / "out"
+
+    summary = bulk_convert(str(source), str(destination))
+
+    assert summary.converted == []
+    assert [src for src, _ in summary.failed] == [str(invalid_json)]
+    assert not (destination / "bad.json").exists()
+
+
 def test_bulk_convert_records_missing_vtt_as_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,6 @@
 from podcast_transcript_convert.errors import (
     InvalidHtmlError,
+    InvalidJsonError,
     InvalidSrtError,
     InvalidVttError,
     InvalidXmlError,
@@ -13,6 +14,7 @@ from podcast_transcript_convert.errors import (
 def test_all_errors_are_transcript_conversion_errors():
     for error in (
         InvalidHtmlError(),
+        InvalidJsonError(),
         InvalidXmlError(),
         NoTranscriptFoundError(),
         InvalidSrtError("bad block"),
@@ -27,6 +29,10 @@ def test_all_errors_are_transcript_conversion_errors():
 
 def test_invalid_xml_error_message():
     assert "XML" in InvalidXmlError().message
+
+
+def test_invalid_json_error_message():
+    assert "JSON" in InvalidJsonError().message
 
 
 def test_no_transcript_found_error_message():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from podcast_transcript_convert.converters.json_to_json import json_file_to_json_file
+from podcast_transcript_convert.errors import InvalidJsonError
 
 SPEC_JSON = {
     "version": "1.0.0",
@@ -35,33 +36,61 @@ def test_json_file_to_json_file_adds_metadata(tmp_path: Path):
     assert data["metadata"] == {"title": "Episode 1"}
 
 
-def test_json_file_to_json_file_non_spec_file_is_skipped(tmp_path: Path):
+def test_json_file_to_json_file_non_spec_file_raises(tmp_path: Path):
     origin = tmp_path / "in.json"
     origin.write_text(json.dumps({"foo": "bar"}))
     destination = tmp_path / "out.json"
 
-    json_file_to_json_file(origin, destination, None)
+    with pytest.raises(InvalidJsonError) as excinfo:
+        json_file_to_json_file(origin, destination, None)
 
+    assert str(origin) in excinfo.value.__notes__
     assert not destination.exists()
 
 
-def test_json_file_to_json_file_missing_segments_is_skipped(tmp_path: Path):
+def test_json_file_to_json_file_missing_segments_raises(tmp_path: Path):
     origin = tmp_path / "in.json"
     origin.write_text(json.dumps({"version": "1.0.0"}))
     destination = tmp_path / "out.json"
 
-    json_file_to_json_file(origin, destination, None)
+    with pytest.raises(InvalidJsonError) as excinfo:
+        json_file_to_json_file(origin, destination, None)
 
+    assert str(origin) in excinfo.value.__notes__
     assert not destination.exists()
 
 
-def test_json_file_to_json_file_invalid_json_raises(tmp_path: Path):
+@pytest.mark.parametrize(
+    "data",
+    [
+        [],
+        {"version": 1, "segments": []},
+        {"version": "1.0.0", "segments": {}},
+    ],
+)
+def test_json_file_to_json_file_invalid_schema_types_raise(
+    tmp_path: Path,
+    data: object,
+):
+    origin = tmp_path / "in.json"
+    origin.write_text(json.dumps(data))
+    destination = tmp_path / "out.json"
+
+    with pytest.raises(InvalidJsonError) as excinfo:
+        json_file_to_json_file(origin, destination, None)
+
+    assert str(origin) in excinfo.value.__notes__
+    assert not destination.exists()
+
+
+def test_json_file_to_json_file_invalid_json_raises_standard_error(tmp_path: Path):
     origin = tmp_path / "in.json"
     origin.write_text("{not valid json")
     destination = tmp_path / "out.json"
 
-    with pytest.raises(json.JSONDecodeError) as excinfo:
+    with pytest.raises(InvalidJsonError) as excinfo:
         json_file_to_json_file(origin, destination, None)
 
     assert str(origin) in excinfo.value.__notes__
+    assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
     assert not destination.exists()


### PR DESCRIPTION
## Summary

- add an `InvalidJsonError` consistent with the other source-format converters
- raise it for malformed JSON and invalid PodcastIndex transcript shapes, with source-path context
- ensure bulk conversion records invalid JSON under `failed` instead of reporting a nonexistent output as converted
- add direct, schema-type, error-contract, and bulk-conversion regression coverage

## Root cause

`json_file_to_json_file` logged and returned when required transcript fields were missing. Because returning normally signaled success, `bulk_convert` added the input to `summary.converted` even though no destination file had been written. Malformed JSON also exposed a lower-level `JSONDecodeError` instead of the converter-specific error contract used by other formats.

## Impact

Callers now receive one stable JSON conversion error for malformed or schema-invalid inputs, and bulk conversion summaries accurately report those files as failures.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check podcast_transcript_convert`
- `uv run pyrefly check`
- `uv run pytest -q` — 109 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/podcast-transcript-convert/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

