### PR TITLE
Validate JSON segment types

### DIFF
--- a/podcast_transcript_convert/converters/json_to_json.py
+++ b/podcast_transcript_convert/converters/json_to_json.py
@@ -21,6 +21,7 @@ def json_file_to_json_file(
         not isinstance(data, dict)
         or not isinstance(data.get("version"), str)
         or not isinstance(data.get("segments"), list)
+        or not all(isinstance(segment, dict) for segment in data["segments"])
     ):
         error = InvalidJsonError()
         error.add_note(str(origin_file))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -66,6 +66,7 @@ def test_json_file_to_json_file_missing_segments_raises(tmp_path: Path):
         [],
         {"version": 1, "segments": []},
         {"version": "1.0.0", "segments": {}},
+        {"version": "1.0.0", "segments": ["invalid"]},
     ],
 )
 def test_json_file_to_json_file_invalid_schema_types_raise(


### PR DESCRIPTION
## Summary

- reject non-object entries in PodcastIndex JSON `segments` lists
- add regression coverage for invalid segment element types

## Why

The converter previously validated that `segments` was a list without validating its elements. Non-object entries could therefore pass conversion and later cause downstream consumers to fail with `TypeError` when reading segment fields.

## Impact

Malformed segment lists now raise the existing `InvalidJsonError`. Valid PodcastIndex JSON behavior is unchanged.

## Validation

- `uv run pytest --cov=podcast_transcript_convert --cov-report=term-missing` — 110 passed, 100% coverage
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check podcast_transcript_convert`
- `uv run pyrefly check`
- `uv build`
- CLI help smoke test


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/podcast-transcript-convert/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

